### PR TITLE
Add browser extension for blocking websites

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,44 @@
+let blockAll = true;
+let blockUntil = null;
+let contextData = {};
+
+chrome.runtime.onInstalled.addListener(() => {
+  blockAll = true;
+  blockUntil = null;
+  contextData = {};
+});
+
+chrome.webRequest.onBeforeRequest.addListener(
+  (details) => {
+    if (blockAll) {
+      return { cancel: true };
+    }
+    return { cancel: false };
+  },
+  { urls: ["<all_urls>"] },
+  ["blocking"]
+);
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "unblock") {
+    blockAll = false;
+    blockUntil = Date.now() + message.timeLimit * 60 * 1000;
+    contextData = message.contextData;
+    sendResponse({ status: "unblocked" });
+  } else if (message.type === "checkBlock") {
+    if (blockUntil && Date.now() > blockUntil) {
+      blockAll = true;
+      blockUntil = null;
+      contextData = {};
+    }
+    sendResponse({ blockAll });
+  }
+});
+
+setInterval(() => {
+  if (blockUntil && Date.now() > blockUntil) {
+    blockAll = true;
+    blockUntil = null;
+    contextData = {};
+  }
+}, 1000);

--- a/content.js
+++ b/content.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('questionnaire-form');
+  const questionContainer = document.getElementById('question-container');
+  const submitButton = document.getElementById('submit-button');
+  const timeLimitInput = document.getElementById('time-limit');
+
+  let questions = [];
+  let currentQuestionIndex = 0;
+  let contextData = {};
+
+  function displayQuestion() {
+    if (currentQuestionIndex < questions.length) {
+      questionContainer.innerText = questions[currentQuestionIndex];
+    } else {
+      submitButton.disabled = false;
+    }
+  }
+
+  function fetchQuestions() {
+    // Fetch questions from the background script
+    chrome.runtime.sendMessage({ type: 'getQuestions' }, function (response) {
+      questions = response.questions;
+      displayQuestion();
+    });
+  }
+
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    const answer = document.getElementById('answer').value;
+    const timeLimit = parseInt(timeLimitInput.value, 10);
+
+    if (currentQuestionIndex < questions.length) {
+      contextData[questions[currentQuestionIndex]] = answer;
+      currentQuestionIndex++;
+      displayQuestion();
+    } else {
+      // Send answers and time limit to the background script
+      chrome.runtime.sendMessage(
+        {
+          type: 'unblock',
+          contextData: contextData,
+          timeLimit: timeLimit,
+        },
+        function (response) {
+          if (response.status === 'unblocked') {
+            alert('Websites are now unblocked for the specified time limit.');
+          }
+        }
+      );
+    }
+  });
+
+  fetchQuestions();
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": 2,
+  "name": "Website Blocker",
+  "version": "1.0",
+  "description": "Blocks all websites until answering domain and contextualization questions.",
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking",
+    "<all_urls>",
+    "storage"
+  ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": true
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/settings.json
+++ b/settings.json
@@ -21,5 +21,9 @@
             "ai_tools": ["chatgpt", "gemini", "bard", "copilot", "claude"],
             "productivity_tools": ["notion", "evernote", "todoist"]
         }
+    },
+    "block_settings": {
+        "initial_block_state": true,
+        "time_limit_minutes": 60
     }
 }


### PR DESCRIPTION
Add a browser extension for Brave that blocks all websites until answering domain and contextualization questions, sets a time limit for a block, and re-blocks websites after the time limit.

* **manifest.json**: Define the browser extension with necessary permissions and scripts.
* **background.js**: Implement logic to block all websites initially, unblock after answering questions, and re-block after the time limit.
* **content.js**: Handle user interaction, display questions, collect answers, and send data to the background script.
* **settings.json**: Add settings for the initial block state and time limit for blocking.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kilo/pull/1?shareId=15744b4d-6c8a-44a1-9b42-4adcd6a68274).