### PR TITLE
Fix extension functionality to block websites and use Python script

### DIFF
--- a/content.js
+++ b/content.js
@@ -17,11 +17,14 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function fetchQuestions() {
-    // Fetch questions from the background script
-    chrome.runtime.sendMessage({ type: 'getQuestions' }, function (response) {
-      questions = response.questions;
-      displayQuestion();
-    });
+    // Fetch questions from the Python script
+    fetch('http://localhost:5000/getQuestions')
+      .then(response => response.json())
+      .then(data => {
+        questions = data.questions;
+        displayQuestion();
+      })
+      .catch(error => console.error('Error fetching questions:', error));
   }
 
   form.addEventListener('submit', function (event) {
@@ -34,10 +37,10 @@ document.addEventListener('DOMContentLoaded', function () {
       currentQuestionIndex++;
       displayQuestion();
     } else {
-      // Send answers and time limit to the background script
+      // Send answers and time limit to the background script for contextualization
       chrome.runtime.sendMessage(
         {
-          type: 'unblock',
+          type: 'contextualize',
           contextData: contextData,
           timeLimit: timeLimit,
         },

--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,8 @@
     "256": "icon-256x256.png",
     "384": "icon-384x384.png",
     "512": "icon-512x512.png"
+  ],
+  "externally_connectable": {
+    "matches": ["http://localhost/*"]
   }
 }


### PR DESCRIPTION
Integrate Python script for domain questions, contextualization, and website analysis into the extension.

* **background.js**
  - Add `analyzeWebsite` function call to check if a website is productive.
  - Modify `chrome.webRequest.onBeforeRequest.addListener` to use `analyzeWebsite` for blocking websites.
  - Update `chrome.runtime.onMessage.addListener` to handle messages for contextualization and domain questions.
  - Add `fetchContextualization` function to fetch contextualization data from the Python script.

* **content.js**
  - Modify `fetchQuestions` function to fetch questions from the Python script.
  - Update form submission to send answers to the background script for contextualization.

* **manifest.json**
  - Add permissions and scripts to link to the Python script for domain questions and contextualization.

* **script.py**
  - Add Flask app to handle requests from the extension for domain questions, contextualization, and website analysis.
  - Add endpoints for `analyzeWebsite`, `getQuestions`, and `contextualize`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kilo/pull/4?shareId=2ef7cd62-7cf2-4d5f-aef1-3a22174e6242).