### PR TITLE
Add website blocker with AI-generated questions and productivity analysis

### DIFF
--- a/background.js
+++ b/background.js
@@ -50,7 +50,12 @@ async function startQuestionnaire(domain) {
 chrome.webRequest.onBeforeRequest.addListener(
   async (details) => {
     const blockedUrl = chrome.runtime.getURL("blocked.html");
-    return { redirectUrl: blockedUrl };
+    const isProductive = await analyzeWebsite(details.url, currentDomain);
+    if (isProductive) {
+      return { cancel: false };
+    } else {
+      return { redirectUrl: blockedUrl };
+    }
   },
   { urls: ["<all_urls>"] },
   ["blocking"]

--- a/content.js
+++ b/content.js
@@ -23,6 +23,9 @@ document.addEventListener('DOMContentLoaded', function () {
       displayQuestion();
     } else if (request.type === 'displayErrorMessage') {
       alert(request.message);
+    } else if (request.type === 'questionnaireComplete') {
+      blockingEnabled = false;
+      sendResponse({ status: 'unblocked' });
     }
   });
 

--- a/popup.js
+++ b/popup.js
@@ -4,5 +4,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
   setDomainButton.addEventListener('click', function () {
     const selectedDomain = domainSelect.value;
+    chrome.runtime.sendMessage({ type: 'setDomain', domain: selectedDomain }, function (response) {
+      if (response.status === 'domainSet') {
+        alert('Domain has been set successfully.');
+      }
+    });
   });
 });


### PR DESCRIPTION
Add logic to set a time limit for the block and analyze productivity during the block.

* **background.js**
  - Modify `chrome.webRequest.onBeforeRequest` to call `analyzeWebsite` function and decide whether to block or unblock the website based on productivity analysis.

* **content.js**
  - Add logic to handle `questionnaireComplete` message and unblock websites.

* **popup.js**
  - Add logic to send the selected domain to the background script and display a success message.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kilo/pull/7?shareId=5cab3d6a-2743-4396-a63b-d5a12c7a31af).