### PR TITLE
Fix 'require is not defined' error in background.js

### DIFF
--- a/background.js
+++ b/background.js
@@ -179,9 +179,13 @@ async function fetchContextualization(domain) {
 }
 
 function logError(...args) {
-  const fs = require('fs');
   const logMessage = args.map(arg => (typeof arg === 'object' ? JSON.stringify(arg) : arg)).join(' ');
-  fs.appendFile('log.txt', logMessage + '\n', (err) => {
-    if (err) throw err;
+  const timestamp = new Date().toISOString();
+  const logEntry = `${timestamp} - ${logMessage}`;
+
+  chrome.storage.local.get({ errorLog: [] }, function (result) {
+    const errorLog = result.errorLog;
+    errorLog.push(logEntry);
+    chrome.storage.local.set({ errorLog: errorLog });
   });
 }

--- a/content.js
+++ b/content.js
@@ -17,10 +17,14 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function logMessage(...args) {
-    const fs = require('fs');
     const logMessage = args.map(arg => (typeof arg === 'object' ? JSON.stringify(arg) : arg)).join(' ');
-    fs.appendFile('log.txt', logMessage + '\n', (err) => {
-      if (err) throw err;
+    const timestamp = new Date().toISOString();
+    const logEntry = `${timestamp} - ${logMessage}`;
+
+    chrome.storage.local.get({ errorLog: [] }, function (result) {
+      const errorLog = result.errorLog;
+      errorLog.push(logEntry);
+      chrome.storage.local.set({ errorLog: errorLog });
     });
   }
 


### PR DESCRIPTION
Refactor `logError` and `logMessage` functions to use `chrome.storage.local` instead of `require('fs')`.

* **background.js**
  - Replace `require('fs')` with `chrome.storage.local` in `logError` function.
  - Write error messages to `chrome.storage.local` with a timestamp in `logError` function.
  - Read and append new error messages to the existing log in `chrome.storage.local` in `logError` function.

* **content.js**
  - Remove `require('fs')` from `logMessage` function.
  - Use `chrome.storage.local` to store log messages in `logMessage` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kilo/pull/11?shareId=77e2af6a-7cc5-4dad-80df-c699668f0cf8).