### PR TITLE
Create .crx update server and deploy as GitHub Page

### DIFF
--- a/.github/workflows/deploy-update-server.yml
+++ b/.github/workflows/deploy-update-server.yml
@@ -1,0 +1,35 @@
+name: Deploy Update Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Generate update.xml
+      run: |
+        python update_server.py
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./
+        publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -68,6 +68,82 @@ We welcome contributions to Eclipse Shield! To contribute, follow these steps:
    ```
 5. Open a pull request on the main repository.
 
+## Setting up GitHub Actions Workflow
+
+To set up the GitHub Actions workflow for deploying the update server, follow these steps:
+
+1. Create a new file `.github/workflows/deploy-update-server.yml` in your repository.
+2. Add the following content to the file:
+   ```yaml
+   name: Deploy Update Server
+
+   on:
+     push:
+       branches:
+         - main
+
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+
+       steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+
+       - name: Set up Python
+         uses: actions/setup-python@v2
+         with:
+           python-version: '3.x'
+
+       - name: Install dependencies
+         run: |
+           python -m pip install --upgrade pip
+           pip install -r requirements.txt
+
+       - name: Generate update.xml
+         run: |
+           python update_server.py
+
+       - name: Deploy to GitHub Pages
+         uses: peaceiris/actions-gh-pages@v3
+         with:
+           github_token: ${{ secrets.GITHUB_TOKEN }}
+           publish_dir: ./
+           publish_branch: gh-pages
+   ```
+
+## Configuring GitHub Pages
+
+To configure your repository for GitHub Pages, follow these steps:
+
+1. Go to the settings of your repository on GitHub.
+2. Scroll down to the "GitHub Pages" section.
+3. Under "Source", select the `gh-pages` branch.
+4. Click "Save".
+
+## Generating and Deploying the `update.xml` File
+
+To generate and deploy the `update.xml` file, follow these steps:
+
+1. Create a new file `update_server.py` in your repository.
+2. Add the following content to the file:
+   ```python
+   import xml.etree.ElementTree as ET
+
+   def generate_update_xml(version, update_url):
+       root = ET.Element("gupdate", xmlns="http://www.google.com/update2/response", protocol="2.0")
+       app = ET.SubElement(root, "app", appid="your-extension-id")
+       updatecheck = ET.SubElement(app, "updatecheck", codebase=update_url, version=version)
+
+       tree = ET.ElementTree(root)
+       tree.write("update.xml", encoding="utf-8", xml_declaration=True)
+
+   if __name__ == "__main__":
+       version = "1.0.0"
+       update_url = "https://your-github-username.github.io/your-repo-name/extension.crx"
+       generate_update_xml(version, update_url)
+   ```
+
 ## Copyright
 
 © 2025 CY83R-3X71NC710N. All rights reserved.

--- a/app.py
+++ b/app.py
@@ -466,6 +466,13 @@ def cleanup_cache_thread_func():
 cleanup_thread = threading.Thread(target=cleanup_cache_thread_func, daemon=True)
 cleanup_thread.start()
 
+@app.route('/update.xml')
+def serve_update_xml():
+    try:
+        return send_from_directory('.', 'update.xml')
+    except Exception as e:
+        app.logger.error(f"Error serving update.xml: {e}")
+        return "Error loading update.xml", 500
 
 # --- Main Execution Block ---
 if __name__ == '__main__':

--- a/update_server.py
+++ b/update_server.py
@@ -1,0 +1,14 @@
+import xml.etree.ElementTree as ET
+
+def generate_update_xml(version, update_url):
+    root = ET.Element("gupdate", xmlns="http://www.google.com/update2/response", protocol="2.0")
+    app = ET.SubElement(root, "app", appid="your-extension-id")
+    updatecheck = ET.SubElement(app, "updatecheck", codebase=update_url, version=version)
+
+    tree = ET.ElementTree(root)
+    tree.write("update.xml", encoding="utf-8", xml_declaration=True)
+
+if __name__ == "__main__":
+    version = "1.0.0"
+    update_url = "https://your-github-username.github.io/your-repo-name/extension.crx"
+    generate_update_xml(version, update_url)


### PR DESCRIPTION
Add a .crx update server and GitHub Actions workflow to deploy it as a GitHub page.

* **Add GitHub Actions Workflow**: Create `.github/workflows/deploy-update-server.yml` to deploy the update server as a GitHub Page. Include steps to check out the repository, set up Python, install dependencies, generate `update.xml`, and deploy to GitHub Pages.
* **Add Update Server Script**: Create `update_server.py` to generate the `update.xml` file using `xml.etree.ElementTree`. Include version and update URL in the XML.
* **Modify App**: Add a route in `app.py` to serve the `update.xml` file using `send_from_directory`.
* **Update Documentation**: Update `README.md` with instructions for setting up the GitHub Actions workflow, configuring GitHub Pages, and generating and deploying the `update.xml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Eclipse-Shield/pull/19?shareId=a371b86f-da26-424e-aa73-cc3596c1ca25).