### PR TITLE
Fix GitHub action to provide URL

### DIFF
--- a/.github/workflows/deploy-update-server.yml
+++ b/.github/workflows/deploy-update-server.yml
@@ -33,3 +33,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./
         publish_branch: gh-pages
+
+    - name: Capture and output URL of deployed site
+      run: echo "url=https://${{ github.repository_owner }}.github.io/${{ github.repository }}" >> $GITHUB_ENV


### PR DESCRIPTION
Add a step to capture and output the URL of the deployed site in the GitHub action.

* Modify `.github/workflows/deploy-update-server.yml` to include a new step that captures the URL of the deployed site and sets it as an output using the `echo` command.
* Construct the URL using the `GITHUB_REPOSITORY` environment variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Eclipse-Shield/pull/21?shareId=c786cbc6-5fea-4a7e-a57b-3ec2bc144992).